### PR TITLE
Раундстарт процедурная планета

### DIFF
--- a/Content.Server/Corvax/CrystallPunk/SpawnMapBiome/SpawnMapBiomeComponent.cs
+++ b/Content.Server/Corvax/CrystallPunk/SpawnMapBiome/SpawnMapBiomeComponent.cs
@@ -1,0 +1,16 @@
+
+using Content.Shared.Parallax.Biomes;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Corvax.CrystallPunk.SpawnMapBiome;
+
+/// <summary>
+/// allows you to initialize a planet on a specific map at initialization time.
+/// </summary>
+
+[RegisterComponent, Access(typeof(SpawnMapBiomeSystem))]
+public sealed partial class SpawnMapBiomeComponent : Component
+{
+    [DataField]
+    public ProtoId<BiomeTemplatePrototype> Biome = "Grasslands";
+}

--- a/Content.Server/Corvax/CrystallPunk/SpawnMapBiome/SpawnMapBiomeSystem.cs
+++ b/Content.Server/Corvax/CrystallPunk/SpawnMapBiome/SpawnMapBiomeSystem.cs
@@ -1,0 +1,25 @@
+using Content.Server.Parallax;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Corvax.CrystallPunk.SpawnMapBiome;
+public sealed partial class SpawnMapBiomeSystem : EntitySystem
+{
+    [Dependency] private readonly BiomeSystem _biome = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+    [Dependency] private readonly IPrototypeManager _proto = default!;
+
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<SpawnMapBiomeComponent, MapInitEvent>(OnMapInit);
+    }
+
+    private void OnMapInit(Entity<SpawnMapBiomeComponent> map, ref MapInitEvent args)
+    {
+        if (!_mapManager.IsMap(map)) return;
+
+        _biome.EnsurePlanet(map, _proto.Index(map.Comp.Biome));
+    }
+}

--- a/Resources/Maps/CrystallPunk/dev_map.yml
+++ b/Resources/Maps/CrystallPunk/dev_map.yml
@@ -391,6 +391,8 @@ entities:
     - type: GridTree
     - type: MovedGrids
     - type: MapLight
+    - type: SpawnMapBiome
+      biome: Grasslands
     - type: DayCycle
       timeEntries:
       - startColor: "#754a4a" #Рассвет


### PR DESCRIPTION
## Описание PR
Добавлена система, позволяющая создавать процедурно генерируемую планету в момент инициализации карты.

Маппить можно в космосе, инициализация мгновенно спавнит планету. Это позволяет редактировать уже замапленные планетарные карты в будущем.